### PR TITLE
Fix Beautifulsoup parser error

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -42,7 +42,7 @@ class OpenGraph(object):
         return response.text
 
     def _parse(self, html):
-        doc = BeautifulSoup(html,  "html5lib")
+        doc = BeautifulSoup(html,  'html.parser')
         ogs = doc.html.head.findAll(property=re.compile(r'^og'))
 
         for og in ogs:

--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -42,7 +42,7 @@ class OpenGraph(object):
         return response.text
 
     def _parse(self, html):
-        doc = BeautifulSoup(html)
+        doc = BeautifulSoup(html,  "html5lib")
         ogs = doc.html.head.findAll(property=re.compile(r'^og'))
 
         for og in ogs:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = (0, 0, 3)
 __version__ = VERSION
 __versionstr__ = '.'.join([str(v) for v in VERSION])
 
-install_requires = ['beautifulsoup4>=4.3', 'requests>=2.7', 'html.parser>=0.0.2']
+install_requires = ['beautifulsoup4>=4.3', 'requests>=2.7']
 test_require = install_requires + ['coverage>=3.7', 'nose>=1.3', 'responses']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = (0, 0, 3)
 __version__ = VERSION
 __versionstr__ = '.'.join([str(v) for v in VERSION])
 
-install_requires = ['beautifulsoup4>=4.3', 'requests>=2.7']
+install_requires = ['beautifulsoup4>=4.3', 'requests>=2.7', 'html.parser>=0.0.2']
 test_require = install_requires + ['coverage>=3.7', 'nose>=1.3', 'responses']
 
 setup(


### PR DESCRIPTION
```bash
/usr/local/lib/python3.5/site-packages/bs4/__init__.py:181: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html5lib"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 11 of the file /usr/local/bin/ipython. To get rid of this warning, change code that looks like this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html5lib")

  markup_type=markup_type))
Out[2]: {}

```